### PR TITLE
Fixes issue 146: Update generate-tags script

### DIFF
--- a/scripts/generate-tags
+++ b/scripts/generate-tags
@@ -9,16 +9,18 @@ Dir.foreach(POSTS_DIR) do |post|
 
   next if post == '.' or post == '..' or post == '.DS_Store'
   postYaml = YAML.load_file(POSTS_DIR + post)
-  postYaml['tags'].each{|tag|
+  unless (postYaml['tags'] == nil)
+    postYaml['tags'].each{|tag|
 
-    unless File.exist?(TAGS_DIR + tag + '.html')
+      unless File.exist?(TAGS_DIR + tag + '.html')
 
-      puts('[+] Generating #' + tag + ' page')
+        puts('[+] Generating #' + tag + ' page')
 
-      File.open(TAGS_DIR + tag + '.html', 'w') {|f| f.write(
-      "---\nlayout: tag\nsection-type: tag\ntitle: " + tag + "\n---\n## Tag")}
+        File.open(TAGS_DIR + tag + '.html', 'w') {|f| f.write(
+        "---\nlayout: tag\nsection-type: tag\ntitle: " + tag + "\n---\n## Tag")}
 
-    end
-  }
+      end
+    }
+  end
 
 end


### PR DESCRIPTION
Fixed bug when posts do not have tags. Script will now happily run as long as the tags field is present in the yaml preamble.
